### PR TITLE
1.0.1 -- Don't send 4xx responses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jumblerg/ring.middleware.cors "1.0.0"
+(defproject jumblerg/ring.middleware.cors "1.0.1"
   :description  "Simple Ring middleware for easy cross-origin resource sharing (CORS)."
   :url          "https://github.com/jumblerg/ring.middleware.cors"
   :license      {:name "Eclipse Public License"


### PR DESCRIPTION
- No need to send 4xx status error responses, because the client is in
  charge of allowing or forbidding the CORS request. We just need to add
  the CORS headers when the client is connecting from an allowed origin.
